### PR TITLE
[버그] UniversalLink forwardRef 파라미터 ref 누락

### DIFF
--- a/src/components/ui/UniversalLink/UniversalLink.tsx
+++ b/src/components/ui/UniversalLink/UniversalLink.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode } from 'react';
+import { forwardRef, ReactNode, Ref } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import NextLink from 'next/link';
 
@@ -7,20 +7,32 @@ export interface UniversalLinkProps {
   children: ReactNode;
 }
 
-const UniversalLink = forwardRef(({ href, children }: UniversalLinkProps) => {
-  if (
-    typeof window === 'undefined' ||
-    'next' in window ||
-    '__NEXT_DATA__' in window
-  ) {
-    return <NextLink href={href || ''}>{children}</NextLink>;
-  }
+const UniversalLink = forwardRef(
+  ({ children, href }: UniversalLinkProps, ref: Ref<HTMLAnchorElement>) => {
+    if (
+      typeof window === 'undefined' ||
+      'next' in window ||
+      '__NEXT_DATA__' in window
+    ) {
+      return (
+        <NextLink href={href || ''} ref={ref}>
+          {children}
+        </NextLink>
+      );
+    }
 
-  if ('ReactRouter' in window) {
-    return <RouterLink to={href || ''}>{children}</RouterLink>;
-  }
+    if ('ReactRouter' in window) {
+      return (
+        <RouterLink to={href || ''} ref={ref}>
+          {children}
+        </RouterLink>
+      );
+    }
 
-  return <a href={href}>{children}</a>;
-});
+    return <a href={href}>{children}</a>;
+  },
+);
+
+UniversalLink.displayName = 'UniversalLink';
 
 export default UniversalLink;

--- a/src/components/ui/UniversalLink/UniversalLink.tsx
+++ b/src/components/ui/UniversalLink/UniversalLink.tsx
@@ -29,7 +29,11 @@ const UniversalLink = forwardRef(
       );
     }
 
-    return <a href={href} ref={ref}>{children}</a>;
+    return (
+      <a href={href} ref={ref}>
+        {children}
+      </a>
+    );
   },
 );
 

--- a/src/components/ui/UniversalLink/UniversalLink.tsx
+++ b/src/components/ui/UniversalLink/UniversalLink.tsx
@@ -29,7 +29,7 @@ const UniversalLink = forwardRef(
       );
     }
 
-    return <a href={href}>{children}</a>;
+    return <a href={href} ref={ref}>{children}</a>;
   },
 );
 


### PR DESCRIPTION
## 🎫 관련 이슈

[//]: # '다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.'
[//]: # 'keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed'
[//]: # '예시: close #1'

close #20

<br>

## 📄 개요

[//]: # '작업 내용을 간단히 요약해서 적습니다.'
[//]: # '예시: 유저 회원가입 기능을 만들었습니다.'

> forwardRef에 ref 파라미터를 추가햇습니다

<br>

## 🔨 작업 내용

[//]: # '작업 내용을 자세하게 적습니다.'
[//]: # '붙임표 "-" 을 사용해서 목록을 만듭니다.'
[//]: # '예시: 유저 회원가입 API를 만들었습니다.'

- ref 파라미터 추가

<br>

## 🏁 확인 사항

[//]: # 'PR을 보내기 전 다음 사항을 확인해주세요.'
[//]: # '해당 사항을 모두 이행해야 머지할 수 있습니다.'
[//]: # '- [x] 를 사용해서 완료로 표시할 수 있습니다.'

- [ ] 테스트를 완료했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말

[//]: # '다음 사항이 있다면 적어주세요.'
[//]: # 'PR에 대한 추가 설명'
[//]: # '중점적으로 리뷰받고 싶은 부분'
[//]: # '기타 등등'
